### PR TITLE
Migrate .gitignore_global to XDG-compliant ~/.config/git/ignore

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,4 +1,0 @@
-*~
-.DS_Store
-node_modules/
-.env

--- a/git/.config/git/ignore
+++ b/git/.config/git/ignore
@@ -1,0 +1,23 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+
+# Windows
+Thumbs.db
+Desktop.ini
+
+# Linux
+*~
+
+# Editors
+*.swp
+*.swo
+.idea/
+*.sublime-*
+
+# Logs
+*.log


### PR DESCRIPTION
- Move global gitignore to ~/.config/git/ignore (Git default location)
- No need for core.excludesfile setting
- Update content to OS/editor-specific only (remove project-specific entries)