### PR TITLE
fix: Remove deprecated homebrew/cask-fonts tap

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -36,6 +36,11 @@ cask "google-japanese-ime"
 cask "visual-studio-code"
 cask "zoom"
 
+# Fonts
+cask "font-plemol-jp"
+cask "font-plemol-jp-hs"
+cask "font-plemol-jp-nf"
+
 # Mac App Store
 mas "Kindle", id: 405399194
 mas "LastPass", id: 926036361


### PR DESCRIPTION
## Summary
- `homebrew/cask-fonts` が2023年に `homebrew/cask` に統合されたため、古いタップを削除
- インストール済みのPlemolJPフォントをBrewfileに追加して将来の環境構築に対応

## 対応内容
- `brew untap homebrew/cask-fonts` で非推奨タップを削除済み
- Brewfileに以下のフォントを追加:
  - font-plemol-jp
  - font-plemol-jp-hs
  - font-plemol-jp-nf

## Test plan
- [x] `brew update` でエラーが発生しないことを確認
- [ ] `brew bundle` で正常にインストールできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)