### PR TITLE
feat: Add Linux support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,10 @@ dotfiles/
 ├── vim/          # .vimrc - 最小限のVim設定
 ├── starship/     # .config/starship.toml - プロンプト
 ├── claude/       # .claude/CLAUDE.md - Claude個人設定
-├── Brewfile      # Homebrew パッケージ定義
-└── setup.sh      # インストールスクリプト
+├── Brewfile      # Homebrew パッケージ定義（macOS）
+├── setup.sh      # インストールスクリプト（OS 自動判別）
+├── packages-linux.sh  # Linux パッケージインストール
+└── docs/         # ドキュメント
 ```
 
 ## Development Guidelines
@@ -57,8 +59,26 @@ stow -R zsh
 - `Brewfile` - `brew bundle` で一括インストール。renovate.json で自動更新
 - `.config/karabiner/karabiner.json` - Caps Lock → Ctrl 等のキーマッピング
 
+## Platform Support
+
+| 項目 | macOS | Linux |
+|------|-------|-------|
+| setup.sh | Homebrew + brew bundle + stow | stow のみ |
+| パッケージ | Brewfile | packages-linux.sh |
+| karabiner | ✅ stow 対象 | 除外（macOS 専用） |
+| クリップボード | pbcopy | xsel |
+
+### Linux セットアップ
+
+```bash
+sudo apt install stow  # Ubuntu/Debian
+./setup.sh
+./packages-linux.sh
+```
+
 ## Notes
 
 - `bin/` 配下のスクリプトは deprecated（zprezto時代の遺産）
 - フォントは `font-plemonl-jp-*` を使用（cask-fonts tap は廃止済み）
 - 環境依存の設定は `command -v` でチェックしてから適用
+- Linux 対応の詳細は `docs/linux-support-plan.md` を参照

--- a/README.md
+++ b/README.md
@@ -13,10 +13,31 @@ cd ~/dotfiles
 ./setup.sh
 ```
 
+### macOS
+
 `setup.sh` は以下を実行します：
 - Homebrew のインストール（未インストールの場合）
 - `brew bundle` でパッケージインストール
-- `stow` で dotfiles をホームディレクトリにリンク
+- `stow` で dotfiles をホームディレクトリにリンク（karabiner 含む）
+
+### Linux
+
+`setup.sh` は以下を実行します：
+- `stow` の存在確認（なければインストール方法を案内）
+- `stow` で dotfiles をホームディレクトリにリンク（karabiner 除外）
+
+パッケージのインストールは別スクリプトで行います：
+
+```bash
+# stow を先にインストール
+sudo apt install stow  # Ubuntu/Debian
+
+# dotfiles をリンク
+./setup.sh
+
+# パッケージをインストール
+./packages-linux.sh
+```
 
 ## Structure
 
@@ -27,8 +48,9 @@ dotfiles/
 ├── vim/.vimrc                    # Vim 設定（最小限）
 ├── starship/.config/starship.toml # プロンプト設定
 ├── claude/.claude/CLAUDE.md      # Claude Code 設定
-├── Brewfile                      # Homebrew パッケージ
-├── setup.sh                      # セットアップスクリプト
+├── Brewfile                      # Homebrew パッケージ（macOS）
+├── setup.sh                      # セットアップスクリプト（OS 自動判別）
+├── packages-linux.sh             # Linux パッケージインストール
 └── docs/                         # ドキュメント
 ```
 
@@ -101,6 +123,17 @@ fi
 
 ## Requirements
 
-- macOS or Linux
-- Homebrew（macOS）または対応するパッケージマネージャー
+- macOS or Linux（WSL2 対応）
 - Git
+- **macOS**: Homebrew（setup.sh が自動インストール）
+- **Linux**: stow（apt/pacman/dnf で事前インストール）
+
+## Platform Support
+
+| 機能 | macOS | Linux |
+|------|-------|-------|
+| setup.sh | ✅ Homebrew + stow | ✅ stow のみ |
+| Brewfile | ✅ | - |
+| packages-linux.sh | - | ✅ apt/pacman/dnf |
+| karabiner | ✅ | - (macOS 専用) |
+| クリップボード連携 | ✅ pbcopy | ✅ xsel |

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "enabledPlugins": {
+    "general@claude-code-marketplace-sample": true
+  },
+  "alwaysThinkingEnabled": true,
   "statusLine": {
     "type": "command",
     "command": "bash ~/.claude/statusline-command.sh"

--- a/docs/linux-support-plan.md
+++ b/docs/linux-support-plan.md
@@ -1,0 +1,223 @@
+# Linux サポート計画
+
+## 概要
+
+macOS 向けに整備してきた dotfiles を Linux（WSL2 含む）でも利用できるようにする。
+
+## 現状分析
+
+### シンボリックリンク状態（Linux 環境）
+
+| ファイル | 状態 |
+|---------|------|
+| `.zshrc` | 未リンク |
+| `.vimrc` | 未リンク |
+| `.gitconfig` | 手動作成（dotfiles と内容が異なる） |
+| `.config/starship.toml` | 未リンク |
+| `.claude/` | 存在（手動設定） |
+
+### クロスプラットフォーム対応状況
+
+| ファイル | 対応状況 | 備考 |
+|---------|----------|------|
+| `zsh/.zshrc` | ✅ 良好 | pbcopy/xsel 分岐、ツール存在チェックあり |
+| `vim/.vimrc` | ✅ 問題なし | OS 依存なし |
+| `git/.gitconfig` | ✅ 問題なし | OS 依存なし |
+| `git/.config/git/ignore` | ✅ 問題なし | macOS/Linux/Windows 対応済み |
+| `starship/.config/starship.toml` | ✅ 問題なし | OS 依存なし |
+| `claude/` | ✅ 問題なし | OS 依存なし |
+| `setup.sh` | ⚠️ 要修正 | Homebrew 前提、OS 分岐なし |
+| `Brewfile` | ❌ macOS 専用 | mas, cask 等 macOS 固有 |
+| `.config/karabiner/` | ❌ macOS 専用 | Karabiner-Elements は macOS のみ |
+| `bin/setup_mac.sh` | ❌ deprecated | 削除候補 |
+| `bin/install_dotfiles.sh` | ❌ deprecated | zprezto 時代の遺産、削除候補 |
+
+### zsh/.zshrc の良好な点
+
+既に以下のクロスプラットフォーム対応が実装済み：
+
+```bash
+# クリップボード分岐
+if which pbcopy >/dev/null 2>&1; then      # macOS
+    alias -g C='| pbcopy'
+elif which xsel >/dev/null 2>&1; then      # Linux
+    alias -g C='| xsel --input --clipboard'
+fi
+
+# ツール存在チェック（graceful degradation）
+if command -v eza &> /dev/null; then
+    alias ls='eza'
+fi
+```
+
+## 修正計画
+
+### Phase 1: 即時対応（共通設定の適用）
+
+Linux 環境で今すぐ stow 可能な設定を適用。
+
+```bash
+cd ~/dotfiles
+stow zsh git vim starship claude
+```
+
+**注意**: karabiner は stow しない（macOS 専用のため）
+
+### Phase 2: setup.sh の OS 分岐追加
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+OS="$(uname -s)"
+
+# 共通の stow 対象
+COMMON_PACKAGES="zsh git vim starship claude"
+
+case "$OS" in
+    Darwin)
+        # Homebrew 初期化
+        if [[ -f /opt/homebrew/bin/brew ]]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        elif [[ -f /usr/local/bin/brew ]]; then
+            eval "$(/usr/local/bin/brew shellenv)"
+        fi
+
+        # パッケージインストール
+        brew install stow
+        brew bundle
+
+        # stow 実行（karabiner 含む）
+        stow $COMMON_PACKAGES karabiner
+        ;;
+
+    Linux)
+        # stow インストール確認
+        if ! command -v stow &> /dev/null; then
+            echo "Please install stow first:"
+            echo "  Ubuntu/Debian: sudo apt install stow"
+            echo "  Arch: sudo pacman -S stow"
+            exit 1
+        fi
+
+        # stow 実行（karabiner 除外）
+        stow $COMMON_PACKAGES
+        ;;
+esac
+
+echo "Setup completed for $OS"
+```
+
+### Phase 3: Linux 用パッケージリスト作成
+
+新規ファイル `packages-linux.sh`:
+
+```bash
+#!/bin/bash
+# Linux 用パッケージインストールスクリプト
+
+set -euo pipefail
+
+# 必須パッケージ（APT）
+ESSENTIAL_PACKAGES=(
+    stow
+    zsh
+    git
+    vim
+    fzf
+    ripgrep
+    jq
+    curl
+    unzip
+)
+
+# Debian/Ubuntu
+if command -v apt &> /dev/null; then
+    sudo apt update
+    sudo apt install -y "${ESSENTIAL_PACKAGES[@]}"
+fi
+
+# 追加ツール（公式インストーラ使用）
+# mise
+curl https://mise.run | sh
+
+# starship
+curl -sS https://starship.rs/install.sh | sh
+
+# zoxide
+curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
+
+# GitHub CLI
+# https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+
+# bat (batcat として提供される場合あり)
+# eza (cargo install 推奨)
+```
+
+### Phase 4: 整理・クリーンアップ
+
+#### 削除対象
+
+- `bin/setup_mac.sh` - deprecated、setup.sh に統合済み
+- `bin/install_dotfiles.sh` - zprezto 時代の遺産
+
+#### Brewfile の整理
+
+macOS 専用セクションを明示的にコメント:
+
+```ruby
+# === Cross-platform CLI tools ===
+brew "fzf"
+brew "bat"
+brew "eza"
+brew "ripgrep"
+brew "jq"
+brew "zoxide"
+brew "stow"
+brew "ghq"
+brew "gh"
+brew "mise"
+brew "starship"
+
+# === macOS only ===
+brew "mas"  # Mac App Store CLI
+
+cask "google-japanese-ime"
+cask "karabiner-elements"
+# ...
+
+mas "Kindle", id: 302584613
+mas "Xcode", id: 497799835
+# ...
+```
+
+## タスクリスト
+
+- [ ] Phase 1: 共通設定を stow で適用
+- [ ] Phase 2: setup.sh に OS 分岐を追加
+- [ ] Phase 3: packages-linux.sh を作成
+- [ ] Phase 4: deprecated スクリプトを削除
+- [ ] Phase 4: Brewfile にセクションコメントを追加
+- [ ] ドキュメント: CLAUDE.md に Linux サポート状況を明記
+
+## 参考: Linux で必要なツールのインストール方法
+
+| ツール | Ubuntu/Debian | 備考 |
+|--------|---------------|------|
+| stow | `apt install stow` | |
+| zsh | `apt install zsh` | |
+| fzf | `apt install fzf` | |
+| bat | `apt install bat` | `batcat` としてインストールされる場合あり |
+| eza | cargo install | `apt` にない場合が多い |
+| ripgrep | `apt install ripgrep` | |
+| jq | `apt install jq` | |
+| zoxide | 公式スクリプト | |
+| starship | 公式スクリプト | |
+| mise | 公式スクリプト | |
+| gh | GitHub 公式リポジトリ追加 | |
+| xsel | `apt install xsel` | クリップボード連携用 |
+
+## 備考
+
+- WSL2 環境では Windows 側のフォント設定が優先されるため、`font-plemol-jp-*` は Windows Terminal 側で設定
+- Karabiner の代替として Linux では `keyd` や `xremap` が利用可能（必要に応じて検討）

--- a/git/.config/git/ignore
+++ b/git/.config/git/ignore
@@ -21,3 +21,6 @@ Desktop.ini
 
 # Logs
 *.log
+
+# Claude Code local settings
+**/.claude/settings.local.json

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,6 +1,9 @@
 [user]
     name = childbamboo
     email = childbamboo1980@gmail.com
+[credential "https://github.com"]
+    helper =
+    helper = !gh auth git-credential
 [push]
     default = current
 [pull]

--- a/packages-linux.sh
+++ b/packages-linux.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Linux 用パッケージインストールスクリプト
+
+set -e
+
+echo "=== Linux packages setup ==="
+
+# ディストリビューション検出
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    DISTRO=$ID
+else
+    DISTRO="unknown"
+fi
+
+echo "Detected distro: $DISTRO"
+
+# === 基本パッケージ（パッケージマネージャ経由） ===
+
+ESSENTIAL_PACKAGES=(
+    stow
+    zsh
+    git
+    vim
+    fzf
+    ripgrep
+    jq
+    curl
+    unzip
+    xsel  # クリップボード連携
+)
+
+case "$DISTRO" in
+    ubuntu|debian)
+        echo "Installing packages via apt..."
+        sudo apt update
+        sudo apt install -y "${ESSENTIAL_PACKAGES[@]}"
+        ;;
+    arch|manjaro)
+        echo "Installing packages via pacman..."
+        sudo pacman -Syu --noconfirm "${ESSENTIAL_PACKAGES[@]}"
+        ;;
+    fedora)
+        echo "Installing packages via dnf..."
+        sudo dnf install -y "${ESSENTIAL_PACKAGES[@]}"
+        ;;
+    *)
+        echo "Unknown distro: $DISTRO"
+        echo "Please install manually: ${ESSENTIAL_PACKAGES[*]}"
+        ;;
+esac
+
+# === 追加ツール（公式インストーラ使用） ===
+
+echo ""
+echo "=== Installing additional tools ==="
+
+# mise (runtime version manager)
+if ! command -v mise &> /dev/null; then
+    echo "Installing mise..."
+    curl https://mise.run | sh
+    echo 'eval "$(~/.local/bin/mise activate bash)"' >> ~/.bashrc
+else
+    echo "mise: already installed"
+fi
+
+# starship (prompt)
+if ! command -v starship &> /dev/null; then
+    echo "Installing starship..."
+    curl -sS https://starship.rs/install.sh | sh -s -- -y
+else
+    echo "starship: already installed"
+fi
+
+# zoxide (smart cd)
+if ! command -v zoxide &> /dev/null; then
+    echo "Installing zoxide..."
+    curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
+else
+    echo "zoxide: already installed"
+fi
+
+# GitHub CLI
+if ! command -v gh &> /dev/null; then
+    echo "Installing GitHub CLI..."
+    case "$DISTRO" in
+        ubuntu|debian)
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt update
+            sudo apt install -y gh
+            ;;
+        arch|manjaro)
+            sudo pacman -S --noconfirm github-cli
+            ;;
+        fedora)
+            sudo dnf install -y gh
+            ;;
+        *)
+            echo "Please install gh manually: https://github.com/cli/cli#installation"
+            ;;
+    esac
+else
+    echo "gh: already installed"
+fi
+
+# === オプション: apt にないツール ===
+
+echo ""
+echo "=== Optional tools (manual install) ==="
+echo ""
+echo "The following tools may need manual installation:"
+echo "  - eza: cargo install eza (or check https://eza.rocks)"
+echo "  - bat: may be installed as 'batcat' on Debian/Ubuntu"
+echo "  - ghq: go install github.com/x-motemen/ghq@latest"
+echo ""
+
+# bat の batcat エイリアス対応（Debian/Ubuntu）
+if command -v batcat &> /dev/null && ! command -v bat &> /dev/null; then
+    echo "Note: 'bat' is installed as 'batcat'. Creating alias..."
+    mkdir -p ~/.local/bin
+    ln -sf "$(which batcat)" ~/.local/bin/bat
+    echo "Symlink created: ~/.local/bin/bat -> batcat"
+fi
+
+echo ""
+echo "=== Setup complete! ==="
+echo ""
+echo "Next steps:"
+echo "  1. Run: source ~/.zshrc"
+echo "  2. Run: gh auth login"
+echo "  3. Optional: chsh -s \$(which zsh)"

--- a/packages-linux.sh
+++ b/packages-linux.sh
@@ -20,6 +20,7 @@ echo "Detected distro: $DISTRO"
 ESSENTIAL_PACKAGES=(
     stow
     zsh
+    zsh-autosuggestions
     git
     vim
     fzf

--- a/packages-linux.sh
+++ b/packages-linux.sh
@@ -81,6 +81,14 @@ else
     echo "zoxide: already installed"
 fi
 
+# Claude CLI
+if ! command -v claude &> /dev/null; then
+    echo "Installing Claude CLI..."
+    curl -fsSL https://claude.ai/install.sh | sh
+else
+    echo "claude: already installed"
+fi
+
 # GitHub CLI
 if ! command -v gh &> /dev/null; then
     echo "Installing GitHub CLI..."

--- a/setup.sh
+++ b/setup.sh
@@ -49,7 +49,14 @@ case "$OS" in
     Linux)
         # === Linux ===
 
-        # stow がなければインストール案内
+        # パッケージインストール
+        SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+        if [[ -f "$SCRIPT_DIR/packages-linux.sh" ]]; then
+            echo "Installing packages..."
+            bash "$SCRIPT_DIR/packages-linux.sh"
+        fi
+
+        # stow がなければエラー（packages-linux.sh でインストール済みのはず）
         if ! command -v stow &> /dev/null; then
             echo "Error: stow is not installed."
             echo "Please install stow first:"
@@ -65,9 +72,6 @@ case "$OS" in
         # stow で dotfiles をリンク（karabiner 除外）
         echo "Linking dotfiles with stow..."
         stow -v $COMMON_PACKAGES
-
-        echo ""
-        echo "Note: Run 'packages-linux.sh' to install recommended packages."
         ;;
 
     *)

--- a/setup.sh
+++ b/setup.sh
@@ -5,35 +5,76 @@ cd "$(dirname "$0")"
 
 echo "=== dotfiles setup ==="
 
-# Homebrew がなければインストール
-if ! command -v brew &> /dev/null; then
-    echo "Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+OS="$(uname -s)"
+echo "Detected OS: $OS"
 
-    # Homebrew のパスを設定
-    if [[ -f /opt/homebrew/bin/brew ]]; then
-        eval "$(/opt/homebrew/bin/brew shellenv)"
-    elif [[ -f /usr/local/bin/brew ]]; then
-        eval "$(/usr/local/bin/brew shellenv)"
-    fi
-fi
+# 共通の stow 対象
+COMMON_PACKAGES="zsh git vim starship claude"
 
-# stow がなければインストール
-if ! command -v stow &> /dev/null; then
-    echo "Installing stow..."
-    brew install stow
-fi
+case "$OS" in
+    Darwin)
+        # === macOS ===
 
-# パッケージインストール
-echo "Installing packages from Brewfile..."
-brew bundle
+        # Homebrew がなければインストール
+        if ! command -v brew &> /dev/null; then
+            echo "Installing Homebrew..."
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-# 必要なディレクトリを作成
-mkdir -p ~/.config
+            # Homebrew のパスを設定
+            if [[ -f /opt/homebrew/bin/brew ]]; then
+                eval "$(/opt/homebrew/bin/brew shellenv)"
+            elif [[ -f /usr/local/bin/brew ]]; then
+                eval "$(/usr/local/bin/brew shellenv)"
+            fi
+        fi
 
-# stow で dotfiles をリンク
-echo "Linking dotfiles with stow..."
-stow -v zsh git vim starship claude
+        # stow がなければインストール
+        if ! command -v stow &> /dev/null; then
+            echo "Installing stow..."
+            brew install stow
+        fi
+
+        # パッケージインストール
+        echo "Installing packages from Brewfile..."
+        brew bundle
+
+        # 必要なディレクトリを作成
+        mkdir -p ~/.config
+
+        # stow で dotfiles をリンク（karabiner 含む）
+        echo "Linking dotfiles with stow..."
+        stow -v $COMMON_PACKAGES karabiner
+        ;;
+
+    Linux)
+        # === Linux ===
+
+        # stow がなければインストール案内
+        if ! command -v stow &> /dev/null; then
+            echo "Error: stow is not installed."
+            echo "Please install stow first:"
+            echo "  Ubuntu/Debian: sudo apt install stow"
+            echo "  Arch Linux:    sudo pacman -S stow"
+            echo "  Fedora:        sudo dnf install stow"
+            exit 1
+        fi
+
+        # 必要なディレクトリを作成
+        mkdir -p ~/.config
+
+        # stow で dotfiles をリンク（karabiner 除外）
+        echo "Linking dotfiles with stow..."
+        stow -v $COMMON_PACKAGES
+
+        echo ""
+        echo "Note: Run 'packages-linux.sh' to install recommended packages."
+        ;;
+
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
 
 echo ""
 echo "=== Setup complete! ==="

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -4,6 +4,11 @@
 export LANG=ja_JP.UTF-8
 export EDITOR=vim
 
+# ~/.local/bin をパスに追加（Claude CLI 等）
+if [[ -d "$HOME/.local/bin" ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
 # ============================================
 # Homebrew
 # ============================================

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -28,8 +28,12 @@ if type brew &>/dev/null; then
 fi
 
 # zsh-autosuggestions
-if [[ -f $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]]; then
+if type brew &>/dev/null && [[ -f $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]]; then
+    # macOS (Homebrew)
     source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+elif [[ -f /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]]; then
+    # Linux (apt)
+    source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 fi
 
 # ============================================


### PR DESCRIPTION
## Summary

- Add OS detection to `setup.sh` (macOS vs Linux)
- Create `packages-linux.sh` for Linux package installation
- Support Ubuntu/Debian, Arch, Fedora distributions
- Add cross-platform support for zsh-autosuggestions
- Add `~/.local/bin` to PATH for Claude CLI
- Add Claude CLI installation
- Merge existing Linux configs (gitconfig, git/ignore, claude settings)
- Document Linux support in README.md and CLAUDE.md

## Changes

| File | Change |
|------|--------|
| `setup.sh` | OS detection, call packages-linux.sh on Linux |
| `packages-linux.sh` | New: Linux package installer |
| `zsh/.zshrc` | Add ~/.local/bin to PATH, Linux zsh-autosuggestions |
| `git/.gitconfig` | Add gh credential helper (cross-platform) |
| `git/.config/git/ignore` | Add Claude local settings |
| `claude/.claude/settings.json` | Merge existing settings |
| `README.md` | Add Linux setup instructions |
| `CLAUDE.md` | Add Platform Support section |
| `docs/linux-support-plan.md` | New: Linux support documentation |

## Test plan

- [ ] Run `./setup.sh` on Linux (WSL2)
- [ ] Run `./setup.sh` on macOS
- [ ] Verify stow links created correctly
- [ ] Verify zsh-autosuggestions works on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)