### PR TITLE
fix: Support older fzf versions without --zsh option

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -113,7 +113,14 @@ fi
 # fzf
 # ============================================
 if command -v fzf &> /dev/null; then
-    source <(fzf --zsh)
+    # fzf 0.48+ supports --zsh option
+    if fzf --zsh &>/dev/null; then
+        source <(fzf --zsh)
+    # Linux (apt): use bundled scripts
+    elif [[ -f /usr/share/doc/fzf/examples/key-bindings.zsh ]]; then
+        source /usr/share/doc/fzf/examples/key-bindings.zsh
+        [[ -f /usr/share/doc/fzf/examples/completion.zsh ]] && source /usr/share/doc/fzf/examples/completion.zsh
+    fi
     export FZF_DEFAULT_OPTS='--height 40% --reverse'
 fi
 


### PR DESCRIPTION
## Summary
- fzf 0.48+ で導入された `--zsh` オプションが古いバージョン（apt インストール等）で `unknown option` エラーになる問題を修正
- バージョンチェックを行い、古い fzf では `/usr/share/doc/fzf/examples/` のスクリプトを使用

## Test plan
- [x] Linux (fzf 0.29) でエラーが出ないことを確認
- [ ] macOS (fzf 0.48+) で従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)