### PR TITLE
feat: Add Docker MCP config and expand dev environment for WSL/Mac

### DIFF
--- a/claude/.claude/.mcp.json
+++ b/claude/.claude/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "MCP_DOCKER": {
+      "command": "docker",
+      "args": ["mcp", "gateway", "run"]
+    }
+  }
+}

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -56,16 +56,25 @@
 
 ## 開発環境
 
-- OS: Windows 11 + WSL 2 (Ubuntu)
-- Docker Desktop (WSL 2 backend) 利用可能
+### 共通
+- Docker Desktop 利用可能
 - Docker Compose v2 利用可能
 - Docker MCP Toolkit 有効（MCP_DOCKER サーバー経由）
+- コードは ~/projects/ 配下に配置する
+
+### WSL 固有（Windows 環境の場合）
+- WSL 2 (Ubuntu) + Docker Desktop WSL 2 backend
+- /mnt/c/ 配下にはコードを置かない（I/O パフォーマンス対策）
+- .wslconfig で memory / processors を制限推奨
+
+### Mac 固有
+- Docker Desktop for Mac
+- リソース制限は Docker Desktop の Settings > Resources で設定
 
 ## 開発ルール
-
 - ローカルの DB やミドルウェアは Docker Compose で管理する
-- コードは WSL ファイルシステム内に配置する（ghq 管理）
-- /mnt/c/ 配下にはコードを置かない（I/O パフォーマンス対策）
+- docker-compose.yml はプロジェクトルートに置く
+- Docker イメージの選定に迷ったら Docker MCP 経由で Docker Hub を検索する
 
 ## Technical Context
 


### PR DESCRIPTION
- Create .mcp.json with MCP_DOCKER server config (docker mcp gateway run)
- Expand 開発環境 section with WSL/Mac subsections for dual-platform support
- Update 開発ルール with Docker Compose and Docker Hub search guidance

https://claude.ai/code/session_01XnHtzgejruoPVqmhX5Sxut